### PR TITLE
Bug/add image node validation

### DIFF
--- a/story/tellmeastory/tests/test_imageOnNode.py
+++ b/story/tellmeastory/tests/test_imageOnNode.py
@@ -107,4 +107,15 @@ class NodeImageTests(TestCase):
             "nodes": all_nodes
         })
         self.assertEqual(res.status_code, 200)
+        # Process basic request with invalid node
+        self.client.get("/story/addnodeimage/")  # Process basic request for prompts
+        res: HttpResponse = self.client.post("/story/addnodeimage/", data={
+            "form": AddImageForm,
+            "err_msg": err_msg,
+            "image_file": test_image_file,
+            "image_url": "",
+            "id": 0,
+            "nodes": all_nodes
+        })
+        self.assertEqual(res.status_code, 200)
         return

--- a/story/tellmeastory/views.py
+++ b/story/tellmeastory/views.py
@@ -235,8 +235,11 @@ def add_image(req: HttpRequest) -> HttpResponse:
             # with undefined node error.
             # TODO: Redirect to view all Nodes page
             #  once Node page is created for an account.
-            node: Node = form["node_id"].value()
-            node = Node.objects.get(id=node)
+            node = form["node_id"].value()
+            if Node.objects.filter(id=node).exists():
+                node = Node.objects.get(id=node)
+            else:
+                node = None
             if node is None:
                 err_msg = "Undefined Node. Image cannot be attached to this node. Please try another node."
             # Otherwise, try to attach new image given


### PR DESCRIPTION
This fixes issue https://github.com/Shah-Kush/TellMeAStory4/issues/60 for validating node id entries. The user shall be reprompted if they give an invalid node to which they would like to attach an image.