### PR TITLE
Feature/integrated story creation

### DIFF
--- a/story/tellmeastory/forms.py
+++ b/story/tellmeastory/forms.py
@@ -28,3 +28,11 @@ class AddImageForm(Form):
     image_file: ImageField = ImageField(required=False)
     image_url: CharField = CharField(max_length=200, required=False)
     node_id: IntegerField = IntegerField(required=True)
+
+class PostStoryForm(Form):
+    # If no image is given, then no image is added.
+    image_file: ImageField = ImageField(required=False)
+    image_url: CharField = CharField(max_length=200, required=False)
+    node_title: CharField = CharField(max_length=200, required=True)
+    node_content: CharField = CharField(max_length=10_000, required=True)
+    mature_node: BooleanField = BooleanField(label="Is this story mature?", required=False)

--- a/story/tellmeastory/forms.py
+++ b/story/tellmeastory/forms.py
@@ -31,8 +31,9 @@ class AddImageForm(Form):
 
 class PostStoryForm(Form):
     # If no image is given, then no image is added.
-    image_file: ImageField = ImageField(required=False)
-    image_url: CharField = CharField(max_length=200, required=False)
     node_title: CharField = CharField(max_length=200, required=True)
     node_content: CharField = CharField(max_length=10_000, required=True)
+    image_file: ImageField = ImageField(required=False)
+    image_url: CharField = CharField(max_length=200, required=False)
+    main_tag_id: IntegerField = IntegerField(required=True)
     mature_node: BooleanField = BooleanField(label="Is this story mature?", required=False)

--- a/story/tellmeastory/forms.py
+++ b/story/tellmeastory/forms.py
@@ -1,4 +1,4 @@
-from django.forms import BooleanField, IntegerField, CharField, ImageField, Form
+from django.forms import BooleanField, IntegerField, FloatField, CharField, ImageField, Form
 from .models import Node, User
 
 class LoginForm(Form):
@@ -37,3 +37,5 @@ class PostStoryForm(Form):
     image_url: CharField = CharField(max_length=200, required=False)
     main_tag_id: IntegerField = IntegerField(required=True)
     mature_node: BooleanField = BooleanField(label="Is this story mature?", required=False)
+    latitude: FloatField = FloatField(required=True)
+    longitude: FloatField = FloatField(required=True)

--- a/story/tellmeastory/models.py
+++ b/story/tellmeastory/models.py
@@ -61,6 +61,12 @@ class User(Model):
         """
         return self.is_mature
 
+    def post_node(self, insertNode) -> bool:
+        """
+        Returns True if node is posted correctly.
+        """
+        return False
+
 class Post(models.Model):
 
     #hold user's id

--- a/story/tellmeastory/models.py
+++ b/story/tellmeastory/models.py
@@ -4,6 +4,7 @@ from django.urls import resolve, Resolver404
 from re import fullmatch, Match
 from validators import url
 from managetags.models import Tag
+from typing import Any, Dict
 
 # Create your models here.
 class User(Model):
@@ -61,11 +62,49 @@ class User(Model):
         """
         return self.is_mature
 
-    def post_node(self, insertNode) -> bool:
+    def post_node(self, contentDict) -> str:
         """
         Returns True if node is posted correctly.
+        contentDict contains:
+            "node_title" -> CharField
+            "node_content" -> CharField
+            "image_file" -> ImageField
+            "image_url" -> CharField
+            "main_tag_id" -> IntegerField
+            "mature_node" -> Bool (true when mature)
         """
-        return False
+        # Add title, content, and author to a new Node to insert
+        node_args: Dict[str, Any] = {
+            "node_title": contentDict["node_title"],
+            "node_content": contentDict["node_content"],
+            "node_author": self
+        }
+        newNode: Node = Node(**node_args)
+        # Check title and content for validity
+        if not newNode.is_valid_title():
+            return "Invalid title"
+        if not newNode.is_valid_content():
+            return "Content is limited to 10,000 characters"
+        # Add image to node (if present) and check validity
+        is_not_one_image = contentDict["image_file"] is not None and contentDict["image_url"] is not None
+        is_image_not_added = False
+        if not newNode.add_image(newURL=contentDict["image_url"]):
+            if not newNode.add_image(newFile=contentDict["image_file"]):
+                is_image_not_added = True
+        if is_not_one_image:
+            return "Invalid Image. You may add one image to each story."
+        newNode.save()
+        # Add main tag to story and validate that it exists
+        if int(contentDict["main_tag_id"]) < 0 or (not newNode.attach_main_tag(Tag.objects.get(id=int(contentDict["main_tag_id"])).add_tag_to_node())):
+            newNode.delete()
+            return "Main Tag not found. Please select a valid main tag."
+        # Add mature rating is node contains mature content
+        if contentDict["mature_node"]:
+            newNode.attach_mature_tag()
+        # Now that everything has been verified. The node can be successfully
+        # saved to the database and the user can receive a success message.
+        newNode.save()
+        return "Successfully Added your Story! Please refresh page to see changes."
 
 class Post(models.Model):
 

--- a/story/tellmeastory/templates/tellmeastory/author_a_node.html
+++ b/story/tellmeastory/templates/tellmeastory/author_a_node.html
@@ -83,7 +83,7 @@
                 </div>
 
                 <div class="row justify-content-center">
-                    <form class=form-group" action="/story/login/" method="post">
+                    <form class=form-group" action="{% url 'tellmeastory:author_story' user.username %}" method="post" enctype="multipart/form-data">
                         {% csrf_token %}
                         {% block content %}
                             {% for field in form %}
@@ -113,10 +113,10 @@
             </div>
 
             <div class="col">
-                                <div class="row justify-content-center">
+                <div class="row justify-content-center">
                     <p>
                       <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#showTags" aria-expanded="false" aria-controls="showTags">
-                        Click to Show Tags
+                        Show Tags
                       </button>
                     </p>
                     <div class="collapse" id="showTags">
@@ -132,11 +132,10 @@
                       </div>
                     </div>
                 </div>
-
                 <div class="row justify-content-center">
                     <p>
                       <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#showStories" aria-expanded="false" aria-controls="showStories">
-                        Click to My Stories
+                        My Stories
                       </button>
                     </p>
                     <div class="collapse" id="showStories">
@@ -145,14 +144,13 @@
                             <br/> My Stories:
                             <ol>
                                 {% for node in nodes %}
-                                    ID: {{ node.id }} Name: {{ node.node_title }} <br/>
+                                    ID: {{ node.id }} Title: {{ node.node_title }} <br/>
                                 {% endfor %}
                             </ol>
                         </p>
                       </div>
                     </div>
                 </div>
-
             </div>
         </div>
     </div>

--- a/story/tellmeastory/templates/tellmeastory/author_a_node.html
+++ b/story/tellmeastory/templates/tellmeastory/author_a_node.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Author A Story</title>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark" style="background-color:#4fbaf7">
+    <a class="navbar-brand" href="#">Tell Me A Story</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+            aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <form class="form-inline my-2 my-lg-0">
+        <input class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search" style="width:400px">
+        <button class="btn btn-success my-2 my-sm-0" type="submit">Search</button>
+    </form>
+
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav mr-auto">
+            <li class="nav-item active">
+                <a class="nav-link" href="/story/map">Map <span class="sr-only">(current)</span></a>
+            </li>
+
+        </ul>
+
+        {% if logged_in_username %}
+
+            <ul class="nav navbar-nav navbar-right">
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button"
+                       data-toggle="dropdown"
+                       aria-haspopup="true" aria-expanded="false" style=" color:white">
+                        My Profile
+                    </a>
+                    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                        <div style="text-align: center">Welcome, {{ logged_in_username }}!</div>
+                        <div class="dropdown-divider"></div>
+                        <a class="dropdown-item" href="/story/profile/{{ logged_in_username }}">My Profile</a>
+                        <a class="dropdown-item" href="/story/account/{{ logged_in_username }}">My Account</a>
+                        {% if user.admin %}
+                        <div class="dropdown-divider"></div>
+                        <a class="dropdown-item" href="#">Administration</a>
+                            {% endif %}
+                        <div class="dropdown-divider"></div>
+                        <a class="dropdown-item" href="#">Log Out</a>
+                    </div>
+                </li>
+            </ul>
+
+        {% else %}
+
+           <ul class="nav navbar-nav navbar-right">
+                <li class="nav-item active">
+                    <a class="nav-link" href="/story/login/">Login <span class="sr-only">(current)</span></a>
+                </li>
+                <li class="nav-item active">
+                    <a class="nav-link" href="/story/register/">Register <span class="sr-only">(current)</span></a>
+                </li>
+
+            </ul>
+
+
+        {% endif %}
+    </div>
+</nav>
+
+
+<section>
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col">
+                <div class="row justify-content-center">
+                    <h2>Author a Story</h2>
+                </div>
+
+                <div class="row justify-content-center">
+                    {% if error_message %}
+                        <div class="alert alert-danger" style="width:50%; text-align:center">{{ error_message }}</div>
+                    {% endif %}
+                </div>
+
+                <div class="row justify-content-center">
+                    <form class=form-group" action="/story/login/" method="post">
+                        {% csrf_token %}
+                        {% block content %}
+                            {% for field in form %}
+                                <div class="form-group">
+                                    <label class="col col-form-label"
+                                           for="id_{{ field.name }}">{{ field.label }}</label>
+                                    <div class="col">
+                                        <input
+                                                type="{{ field.field.widget.input_type }}"
+                                                class="form-control"
+                                                name="{{ field.name }}"
+                                                id="id_{{ field.name }}"
+                                                value="{{ field.value|default:'' }}"
+                                                style="width:300px"
+                                        >
+                                    </div>
+                                </div>
+                            {% endfor %}
+                            <div class="form-group row justify-content-center">
+                                <input type="submit" value="Create" class="btn btn-primary" style="width:150px">
+                            </div>
+
+                        {% endblock %}
+                    </form>
+                </div>
+
+            </div>
+
+            <div class="col">
+                                <div class="row justify-content-center">
+                    <p>
+                      <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#showTags" aria-expanded="false" aria-controls="showTags">
+                        Click to Show Tags
+                      </button>
+                    </p>
+                    <div class="collapse" id="showTags">
+                      <div class="card card-body" style="width: 18rem;">
+                        <p>
+                            <br/> Existing Tags:
+                            <ol>
+                                {% for tag in tags %}
+                                    ID: {{ tag.id }} Name: {{ tag.name_text }} <br/>
+                                {% endfor %}
+                            </ol>
+                        </p>
+                      </div>
+                    </div>
+                </div>
+
+                <div class="row justify-content-center">
+                    <p>
+                      <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#showStories" aria-expanded="false" aria-controls="showStories">
+                        Click to My Stories
+                      </button>
+                    </p>
+                    <div class="collapse" id="showStories">
+                      <div class="card card-body" style="width: 18rem;">
+                        <p>
+                            <br/> My Stories:
+                            <ol>
+                                {% for node in nodes %}
+                                    ID: {{ node.id }} Name: {{ node.node_title }} <br/>
+                                {% endfor %}
+                            </ol>
+                        </p>
+                      </div>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+</section>
+<!-- https://docs.djangoproject.com/en/4.0/topics/forms/ -->
+
+
+</body>
+
+</html>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css"
+      integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+        integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+        crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js"
+        integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
+        crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js"
+        integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+        crossorigin="anonymous"></script>
+
+<style>
+    section {
+        margin-top: 150px;
+    }
+
+</style>
+

--- a/story/tellmeastory/templates/tellmeastory/author_a_node.html
+++ b/story/tellmeastory/templates/tellmeastory/author_a_node.html
@@ -81,7 +81,7 @@
                         <div class="alert alert-danger" style="width:50%; text-align:center">{{ error_message }}</div>
                     {% endif %}
                 </div>
-
+                <! –– Prompt user with fields for posting a story  -->
                 <div class="row justify-content-center">
                     <form class=form-group" action="{% url 'tellmeastory:author_story' user.username %}" method="post" enctype="multipart/form-data">
                         {% csrf_token %}
@@ -111,7 +111,7 @@
                 </div>
 
             </div>
-
+            <! –– Allow user to view their existing stories  -->
             <div class="col">
                 <div class="row justify-content-center">
                     <p>

--- a/story/tellmeastory/tests/test_imageOnNode.py
+++ b/story/tellmeastory/tests/test_imageOnNode.py
@@ -37,6 +37,7 @@ class NodeImageTests(TestCase):
         node: Node = Node(node_title="Test2")
         node.save()
         self.assertIs(Node.objects.get(id=node.id).add_image(newURL=test_image_url), True)
+        self.assertIs(Node.objects.get(id=node.id).has_image_file, False)
         # Add an image from an invalid URL
         test_image_url = "invalidlink_testing"
         node: Node = Node(node_title="Test3")

--- a/story/tellmeastory/tests/test_integrated_nodecreation.py
+++ b/story/tellmeastory/tests/test_integrated_nodecreation.py
@@ -1,44 +1,135 @@
 from django.test import TestCase
 from tellmeastory.models import Node, User
+from managetags.models import Tag
 from selenium import webdriver
 from django.test import LiveServerTestCase
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.common.by import By
 
-class AddNodeFromUserTests(TestCase):
+class AddNodeFromUserTests(LiveServerTestCase):
 
     def test_enter_node_information(self):
         """
+        Function contains Sections 1 and 2.
+        Section 1 is Setup and Input
+        Section 2 is Submission and Check
+
+        Section 1 of Function
         Test a user entering information about a node.
         The fields should all be present for title, text
         content, image, and tags.
         """
-        return
-
-    def test_submit_node_information(self):
+        # Create a test user for login
+        username = "namename"
+        password = "password1"
+        display_name = "display"
+        # Register above credentials
+        selenium_browser = webdriver.Chrome(ChromeDriverManager().install())
+        selenium_browser.get('%s%s' % (self.live_server_url, '/register/'))
+        username_input = selenium_browser.find_element(By.NAME, value="username")
+        username_input.send_keys(username)  # Enter username
+        password_input = selenium_browser.find_element(By.NAME, value="password")
+        password_input.send_keys(password)  # Enter password
+        display_name_input = selenium_browser.find_element(By.NAME, value="display_name")
+        display_name_input.send_keys(display_name)  # Enter display name
+        selenium_browser.find_element(By.XPATH, value='//input[@value="Register"]').click()
+        # Login using the above credientials
+        selenium_browser.get('%s%s' % (self.live_server_url, '/login/'))
+        username_input = selenium_browser.find_element(By.NAME, value="username")
+        username_input.send_keys(username)  # Enter username
+        password_input = selenium_browser.find_element(By.NAME, value="password")
+        password_input.send_keys(password)  # Enter password
+        selenium_browser.find_element(By.XPATH, value='//input[@value="Login"]').click()
+        # Navigate to Story Posting for given user
+        selenium_browser.get('%s%s' % (self.live_server_url, '/author-story/'+username))
+        # Enter Title, Content, One Image, and a Main Tag ID (after first creating a Tag)
+        TagToInsert = Tag(name_text="name123", language="en_US")
+        TagToInsert.add_new_tag() # Create Main Tag to Add
+        title_input = selenium_browser.find_element(By.NAME, value="node_title")
+        title_input.send_keys("title")  # Enter story title
+        content_input = selenium_browser.find_element(By.NAME, value="node_content")
+        content_input.send_keys("content")  # Enter story content
+        image_input = selenium_browser.find_element(By.NAME, value="image_url")
+        image_input.send_keys("www.google.com")  # Enter valid URL
+        main_tag_input = selenium_browser.find_element(By.NAME, value="main_tag_id")
+        main_tag_input.send_keys(TagToInsert.id)  # Enter valid tag id
         """
+        Section 2 of Function
         Tests submitting a node with various data
-        needed for a node.
+        needed for a node and check if node was 
+        correctly saved.
+        """
+        # Submit content entered from above
+        selenium_browser.find_element(By.XPATH, value='//input[@value="Create"]').click()
+        # Check that node success message was printed
+        success_message = "Successfully Added your Story!"
+        self.assertTrue(selenium_browser.page_source.find(success_message) != -1)
+        # Check that node exists and the author is the user that registered
+        self.assertTrue(Tag.objects.count())  # Check if tags exist
+        self.assertTrue(Node.objects.count())  # Check if nodes exist
+        self.assertTrue(Node.objects.filter(node_author__username=username).first().node_title == "title")  # Check title
+        self.assertTrue(Node.objects.filter(node_author__username=username).first().node_content == "content")  # Check content
+        self.assertFalse(Node.objects.filter(node_author__username=username).first().has_image_file)  # Check image
+        self.assertTrue(Node.objects.filter(node_author__username=username).first().main_tag_id == TagToInsert.id)  # Check main tag
+        return
+
+    def test_add_invalid_story_fields(self):
+        """
+        Tests invalid input for all story fields. The correct error
+        message should appear and no additional nodes should exist.
         """
         return
 
-    def test_author_story(self):
-        """
-        Tests if a logged in user submitting a node
-        can author a story as their user.
-        """
-        return
-
-    def test_attach_tag_to_authored_story(self):
-        """
-        Tests if a tag can be attached to a story
-        and if a new tag can be attached to a story.
-        """
-        return
-
-    def test_existing_stories_present(self):
+    def test_existing_stories_and_tags_present(self):
         """
         Tests if the existing stories of a user are present
-        on the node creation page.
+        on the node creation page and tags too.
         """
+        # Create a test user for login
+        username = "namename"
+        password = "password1"
+        display_name = "display"
+        # Register above credentials
+        selenium_browser = webdriver.Chrome(ChromeDriverManager().install())
+        selenium_browser.get('%s%s' % (self.live_server_url, '/register/'))
+        username_input = selenium_browser.find_element(By.NAME, value="username")
+        username_input.send_keys(username)  # Enter username
+        password_input = selenium_browser.find_element(By.NAME, value="password")
+        password_input.send_keys(password)  # Enter password
+        display_name_input = selenium_browser.find_element(By.NAME, value="display_name")
+        display_name_input.send_keys(display_name)  # Enter display name
+        selenium_browser.find_element(By.XPATH, value='//input[@value="Register"]').click()
+        # Login using the above credientials
+        selenium_browser.get('%s%s' % (self.live_server_url, '/login/'))
+        username_input = selenium_browser.find_element(By.NAME, value="username")
+        username_input.send_keys(username)  # Enter username
+        password_input = selenium_browser.find_element(By.NAME, value="password")
+        password_input.send_keys(password)  # Enter password
+        selenium_browser.find_element(By.XPATH, value='//input[@value="Login"]').click()
+        # Navigate to Story Posting for given user
+        selenium_browser.get('%s%s' % (self.live_server_url, '/author-story/'+username))
+        # Enter Title, Content, One Image, and a Main Tag ID (after first creating a Tag)
+        TagToInsert = Tag(name_text="name123", language="en_US")
+        TagToInsert.add_new_tag() # Create Main Tag to Add
+        title_input = selenium_browser.find_element(By.NAME, value="node_title")
+        title_input.send_keys("title")  # Enter story title
+        content_input = selenium_browser.find_element(By.NAME, value="node_content")
+        content_input.send_keys("content")  # Enter story content
+        image_input = selenium_browser.find_element(By.NAME, value="image_url")
+        image_input.send_keys("www.google.com")  # Enter valid URL
+        main_tag_input = selenium_browser.find_element(By.NAME, value="main_tag_id")
+        main_tag_input.send_keys(TagToInsert.id)  # Enter valid tag id
+        # Submit content entered from above
+        selenium_browser.find_element(By.XPATH, value='//input[@value="Create"]').click()
+        """ Now the stories should be present as well as the tags on the posting page. """
+        # Navigate to Story Posting for given user
+        selenium_browser.get('%s%s' % (self.live_server_url, '/author-story/'+username))
+        # Check if the added tag is present on the page with its ID
+        tag_with_ID = "ID: " + str(TagToInsert.id) + " Name: " + TagToInsert.name_text
+        self.assertTrue(selenium_browser.page_source.find(tag_with_ID) != -1)
+        # Check if the added story is present on the page with its ID
+        story_with_ID = "ID: " + str(Node.objects.filter(node_author__username=username).first().id)\
+                      + " Title: " + Node.objects.filter(node_author__username=username).first().node_title
+        self.assertTrue(selenium_browser.page_source.find(story_with_ID) != -1)
         return
+

--- a/story/tellmeastory/tests/test_integrated_nodecreation.py
+++ b/story/tellmeastory/tests/test_integrated_nodecreation.py
@@ -172,8 +172,30 @@ class AddNodeFromUserTests(LiveServerTestCase):
         password_input = selenium_browser.find_element(By.NAME, value="password")
         password_input.send_keys(password)  # Enter password
         selenium_browser.find_element(By.XPATH, value='//input[@value="Login"]').click()
-        # Navigate to Story Posting for given user
-        selenium_browser.get('%s%s' % (self.live_server_url, '/author-story/'+username))
+        # Check for stories posted by other users (should be none)
+        # Create a temporary Test user for calling post function
+        newusername = "namename1"
+        newpassword = "password2"
+        newdisplay_name = "display1"
+        newuser = User.objects.create(username=newusername, password=sha512(newpassword.encode("utf-8")).hexdigest(), display_name=newdisplay_name)
+        # Create test tag
+        NewTagToInsert = Tag(name_text="differentTag", language="en_US")
+        NewTagToInsert.add_new_tag() # Create Main Tag to Add
+        valid_node_dict = {
+                    "node_title": "title",
+                    "node_content": "content",
+                    "image_file": None,
+                    "image_url": "www.google.com",
+                    "main_tag_id": NewTagToInsert.id,
+                    "mature_node": False,
+                    "latitude": 90,
+                    "longitude": 90
+                }
+        newuser.post_node(valid_node_dict)
+        present_story = "ID: " + str(Node.objects.filter(node_author__username=newusername).first().id)\
+                      + " Title: " + Node.objects.filter(node_author__username=newusername).first().node_title
+        selenium_browser.get('%s%s' % (self.live_server_url, '/author-story/'+username))  # Navigate to Story Posting for a different user
+        self.assertTrue(selenium_browser.page_source.find(present_story) == -1)  # It should not find another user's story on creation page
         # Enter Title, Content, One Image, and a Main Tag ID (after first creating a Tag)
         TagToInsert = Tag(name_text="name123", language="en_US")
         TagToInsert.add_new_tag() # Create Main Tag to Add

--- a/story/tellmeastory/tests/test_integrated_nodecreation.py
+++ b/story/tellmeastory/tests/test_integrated_nodecreation.py
@@ -8,37 +8,37 @@ from selenium.webdriver.common.by import By
 class AddNodeFromUserTests(TestCase):
 
     def test_enter_node_information(self):
-        '''
+        """
         Test a user entering information about a node.
         The fields should all be present for title, text
         content, image, and tags.
-        '''
+        """
         return
 
     def test_submit_node_information(self):
-        '''
+        """
         Tests submitting a node with various data
         needed for a node.
-        '''
+        """
         return
 
     def test_author_story(self):
-        '''
+        """
         Tests if a logged in user submitting a node
         can author a story as their user.
-        '''
+        """
         return
 
     def test_attach_tag_to_authored_story(self):
-        '''
+        """
         Tests if a tag can be attached to a story
         and if a new tag can be attached to a story.
-        '''
+        """
         return
 
     def test_existing_stories_present(self):
-        '''
+        """
         Tests if the existing stories of a user are present
         on the node creation page.
-        '''
+        """
         return

--- a/story/tellmeastory/tests/test_integrated_nodecreation.py
+++ b/story/tellmeastory/tests/test_integrated_nodecreation.py
@@ -1,0 +1,44 @@
+from django.test import TestCase
+from tellmeastory.models import Node, User
+from selenium import webdriver
+from django.test import LiveServerTestCase
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.common.by import By
+
+class AddNodeFromUserTests(TestCase):
+
+    def test_enter_node_information(self):
+        '''
+        Test a user entering information about a node.
+        The fields should all be present for title, text
+        content, image, and tags.
+        '''
+        return
+
+    def test_submit_node_information(self):
+        '''
+        Tests submitting a node with various data
+        needed for a node.
+        '''
+        return
+
+    def test_author_story(self):
+        '''
+        Tests if a logged in user submitting a node
+        can author a story as their user.
+        '''
+        return
+
+    def test_attach_tag_to_authored_story(self):
+        '''
+        Tests if a tag can be attached to a story
+        and if a new tag can be attached to a story.
+        '''
+        return
+
+    def test_existing_stories_present(self):
+        '''
+        Tests if the existing stories of a user are present
+        on the node creation page.
+        '''
+        return

--- a/story/tellmeastory/tests/test_integrated_nodecreation.py
+++ b/story/tellmeastory/tests/test_integrated_nodecreation.py
@@ -54,6 +54,11 @@ class AddNodeFromUserTests(LiveServerTestCase):
         image_input.send_keys("www.google.com")  # Enter valid URL
         main_tag_input = selenium_browser.find_element(By.NAME, value="main_tag_id")
         main_tag_input.send_keys(TagToInsert.id)  # Enter valid tag id
+        # Enter longitude and latitude
+        title_input = selenium_browser.find_element(By.NAME, value="latitude")
+        title_input.send_keys(90)  # Enter latitude
+        title_input = selenium_browser.find_element(By.NAME, value="longitude")
+        title_input.send_keys(90)  # Enter longitude
         """
         Section 2 of Function
         Tests submitting a node with various data
@@ -94,7 +99,9 @@ class AddNodeFromUserTests(LiveServerTestCase):
                     "image_file": None,
                     "image_url": "www.google.com",
                     "main_tag_id": TagToInsert.id,
-                    "mature_node": False
+                    "mature_node": False,
+                    "latitude": 90,
+                    "longitude": 90
                 }
         self.assertTrue(invalid_title_err, user.post_node(invalid_node_dict))
         # Test invalid content response
@@ -106,7 +113,9 @@ class AddNodeFromUserTests(LiveServerTestCase):
                     "image_file": None,
                     "image_url": "www.google.com",
                     "main_tag_id": TagToInsert.id,
-                    "mature_node": False
+                    "mature_node": False,
+                    "latitude": 90,
+                    "longitude": 90
                 }
         self.assertTrue(invalid_title_err, user.post_node(invalid_node_dict))
         # Test invalid image response
@@ -117,7 +126,9 @@ class AddNodeFromUserTests(LiveServerTestCase):
                     "image_file": "www.google.com",
                     "image_url": "www.google.com",
                     "main_tag_id": TagToInsert.id,
-                    "mature_node": False
+                    "mature_node": False,
+                    "latitude": 90,
+                    "longitude": 90
                 }
         self.assertTrue(invalid_title_err, user.post_node(invalid_node_dict))
         # Test invalid main tag response
@@ -128,7 +139,9 @@ class AddNodeFromUserTests(LiveServerTestCase):
                     "image_file": None,
                     "image_url": "www.google.com",
                     "main_tag_id": -1,
-                    "mature_node": False
+                    "mature_node": False,
+                    "latitude": 90,
+                    "longitude": 90
                 }
         self.assertTrue(invalid_title_err, user.post_node(invalid_node_dict))
         return
@@ -172,6 +185,11 @@ class AddNodeFromUserTests(LiveServerTestCase):
         image_input.send_keys("www.google.com")  # Enter valid URL
         main_tag_input = selenium_browser.find_element(By.NAME, value="main_tag_id")
         main_tag_input.send_keys(TagToInsert.id)  # Enter valid tag id
+        # Enter longitude and latitude
+        title_input = selenium_browser.find_element(By.NAME, value="latitude")
+        title_input.send_keys(90)  # Enter latitude
+        title_input = selenium_browser.find_element(By.NAME, value="longitude")
+        title_input.send_keys(90)  # Enter longitude
         # Submit content entered from above
         selenium_browser.find_element(By.XPATH, value='//input[@value="Create"]').click()
         """ Now the stories should be present as well as the tags on the posting page. """
@@ -184,5 +202,71 @@ class AddNodeFromUserTests(LiveServerTestCase):
         story_with_ID = "ID: " + str(Node.objects.filter(node_author__username=username).first().id)\
                       + " Title: " + Node.objects.filter(node_author__username=username).first().node_title
         self.assertTrue(selenium_browser.page_source.find(story_with_ID) != -1)
+        return
+
+    def test_long_lat_input(self):
+        """
+        Tests will run to check for invalid long
+        and lat values given to posting function.
+        """
+        # Create a temporary Test user for calling post function
+        username = "namename"
+        password = "password1"
+        display_name = "display"
+        user = User.objects.create(username=username, password=sha512(password.encode("utf-8")).hexdigest(), display_name=display_name)
+        # Create test tag
+        TagToInsert = Tag(name_text="name123", language="en_US")
+        TagToInsert.add_new_tag() # Create Main Tag to Add
+        # Test invalid responses
+        invalid_lat_err = "Invalid latitude"
+        invalid_long_err = "Invalid longitude"
+        # Test overly large latitude
+        invalid_node_dict = {
+                    "node_title": "title",
+                    "node_content": "content",
+                    "image_file": None,
+                    "image_url": "www.google.com",
+                    "main_tag_id": TagToInsert.id,
+                    "mature_node": False,
+                    "latitude": 91,
+                    "longitude": 90
+                }
+        self.assertTrue(invalid_lat_err, user.post_node(invalid_node_dict))
+        # Test overly small latitude
+        invalid_node_dict = {
+                    "node_title": "title",
+                    "node_content": "content",
+                    "image_file": None,
+                    "image_url": "www.google.com",
+                    "main_tag_id": TagToInsert.id,
+                    "mature_node": False,
+                    "latitude": -91,
+                    "longitude": 90
+                }
+        self.assertTrue(invalid_lat_err, user.post_node(invalid_node_dict))
+        # Test overly large longitude
+        invalid_node_dict = {
+                    "node_title": "title",
+                    "node_content": "content",
+                    "image_file": None,
+                    "image_url": "www.google.com",
+                    "main_tag_id": TagToInsert.id,
+                    "mature_node": False,
+                    "latitude": 90,
+                    "longitude": 181
+                }
+        self.assertTrue(invalid_long_err, user.post_node(invalid_node_dict))
+        # Test overly small longitude
+        invalid_node_dict = {
+                    "node_title": "title",
+                    "node_content": "content",
+                    "image_file": None,
+                    "image_url": "www.google.com",
+                    "main_tag_id": TagToInsert.id,
+                    "mature_node": False,
+                    "latitude": 90,
+                    "longitude": -181
+                }
+        self.assertTrue(invalid_long_err, user.post_node(invalid_node_dict))
         return
 

--- a/story/tellmeastory/urls.py
+++ b/story/tellmeastory/urls.py
@@ -15,5 +15,6 @@ urlpatterns = [
     path("profile/<str:username>/", views.profile, name="profile"),
     path("addtags/", include("managetags.urls")),
     path("addnodeimage/", views.add_image, name="add_node_image"),
-    path("create-story/", views.create_node, name="create_story")
+    path("create-story/", views.create_node, name="create_story"),
+    path("author-story/<str:username>/", views.author_story, name="author_story"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/story/tellmeastory/views.py
+++ b/story/tellmeastory/views.py
@@ -3,8 +3,9 @@ import json
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from hashlib import sha512
-from .forms import LoginForm, NameChangeForm, AddImageForm, NodeCreationForm, RegisterForm
+from .forms import LoginForm, NameChangeForm, AddImageForm, NodeCreationForm, RegisterForm, PostStoryForm
 from .models import User, Post, Node
+from managetags.models import Tag
 from typing import Any, Dict
 from .constants import *
 
@@ -332,3 +333,98 @@ def profile(req: HttpRequest, username:str) -> HttpResponse:
         "stories": storiesFromUser,
         "story_count": storyCount,
     })
+
+
+def author_story(req: HttpRequest, username: str) -> HttpResponse:
+    user: User = get_object_or_404(User, username=username)
+    err_msg = None
+    all_nodes = Node.objects.filter()
+    my_nodes = []
+    all_tags = Tag.objects.filter()
+    form = PostStoryForm()
+    logged_user: str = req.COOKIES.get(COOKIE_NAME)
+
+    # Find all of a user's stories
+    if logged_user == username:
+        # User account should exist, otherwise they have no nodes
+        try:
+            user = User.objects.get(username=username)
+            for curNode in all_nodes:
+                if curNode.node_author == user:
+                    my_nodes.append(curNode)
+        except User.DoesNotExist:
+            my_nodes = []
+
+    # If POST, then process new node authored by user, else
+    # send to node creation page.
+    if req.method == "POST":
+        # Check for a valid POST request and that
+        # the given username is what their cookie
+        # shows.
+        form: PostStoryForm() = PostStoryForm(req.POST)
+        if form.is_valid():
+            if logged_user == username:
+                # User account should exist, otherwise send them
+                # to the login page.
+                try:
+                    user = User.objects.get(username=username)
+                except User.DoesNotExist:
+                    err_msg = "Account does not exist."
+                    form: LoginForm = LoginForm()
+                    return render(req, "tellmeastory/login.html", {
+                        "form": form,
+                        "error_message": err_msg
+                    })
+                # CREATE STORY NODE FROM PROVIDED INFORMATION
+                err_msg = user.post_node({
+                    "node_title": form["node_title"].value().strip(),
+                    "node_content": form["node_content"].value().strip(),
+                    "image_file": form["image_file"].value(),
+                    "image_url": form["image_url"].value(),
+                    "main_tag_id": form["main_tag_id"].value(),
+                    "mature_node": form["mature_node"].value()
+                })
+                # Present error if any exists, update my nodes and present
+                # blank form.
+                form = PostStoryForm()
+                return render(req, "tellmeastory/author_a_node.html", {
+                    "user": user,
+                    "form": form,
+                    "error_message": err_msg,
+                    "nodes": my_nodes,
+                    "tags": all_tags,
+                    "logged_in_username": logged_user
+                })
+            # If cookie does not match username, send to
+            # login page.
+            else:
+                form: LoginForm = LoginForm()
+                err_msg = "Account not found. Try adding a story later."
+                return render(req, "tellmeastory/login.html", {
+                    "form": form,
+                    "error_message": err_msg
+                })
+        else:
+            # Reprompt when invalid form is submitted
+            form = PostStoryForm(req.POST)
+            err_msg = "Invalid Story. All fields are required except the image. Only one image is allowed."
+            return render(req, "tellmeastory/author_a_node.html", {
+                "user": user,
+                "form": form,
+                "error_message": err_msg,
+                "nodes": my_nodes,
+                "tags": all_tags,
+                "logged_in_username": logged_user
+            })
+    # Prompt with node creation page.
+    else:
+        # Render the page with node creation form and
+        # all nodes of current user.
+        return render(req, "tellmeastory/author_a_node.html", {
+                "user": user,
+                "form": form,
+                "error_message": err_msg,
+                "nodes": my_nodes,
+                "tags": all_tags,
+                "logged_in_username": logged_user
+            })

--- a/story/tellmeastory/views.py
+++ b/story/tellmeastory/views.py
@@ -382,7 +382,9 @@ def author_story(req: HttpRequest, username: str) -> HttpResponse:
                     "image_file": form["image_file"].value(),
                     "image_url": form["image_url"].value(),
                     "main_tag_id": form["main_tag_id"].value(),
-                    "mature_node": form["mature_node"].value()
+                    "mature_node": form["mature_node"].value(),
+                    "latitude": form["latitude"].value(),
+                    "longitude": form["longitude"].value()
                 })
                 # Present error if any exists, update my nodes and present
                 # blank form.


### PR DESCRIPTION
The primary story authoring functionality is added in this pull request. Users are allowed to use their accounts to create stories authored by themselves. The fields they can currently enter are the previously implemented title, text content, images, main tag, maturity tag, longitude, and latitude. The user's available tags and current stories are listed when the corresponding buttons are pressed. The long/lat are only saved, but they are not used yet. The tests are located in story/tellmeastory/tests/test_integrated_nodecreation.