### PR TITLE
Added no tags exist check and fixed image posting

### DIFF
--- a/story/tellmeastory/models.py
+++ b/story/tellmeastory/models.py
@@ -97,7 +97,7 @@ class User(Model):
             return "Invalid Image. You may add one image to each story."
         newNode.save()  # Every return after this MUST delete newNode, it was saved to create its id for ManyToMany
         # Add main tag to story and validate that it exists
-        if int(contentDict["main_tag_id"]) < 0 or (not newNode.attach_main_tag(Tag.objects.get(id=int(contentDict["main_tag_id"])).add_tag_to_node())):
+        if (not Tag.objects.count()) or (int(contentDict["main_tag_id"]) < 0) or (not newNode.attach_main_tag(Tag.objects.get(id=int(contentDict["main_tag_id"])).add_tag_to_node())):
             newNode.delete()
             return "Main Tag not found. Please select a valid main tag."
         # Add mature rating is node contains mature content

--- a/story/tellmeastory/tests/test_integrated_nodecreation.py
+++ b/story/tellmeastory/tests/test_integrated_nodecreation.py
@@ -6,6 +6,7 @@ from django.test import LiveServerTestCase
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.common.by import By
 from hashlib import sha512
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 class AddNodeFromUserTests(LiveServerTestCase):
 
@@ -78,7 +79,7 @@ class AddNodeFromUserTests(LiveServerTestCase):
         self.assertFalse(Node.objects.filter(node_author__username=username).first().has_image_file)  # Check image (should only have url, not file)
         return
 
-    def test_add_invalid_story_fields(self):
+    def test_add_invalid_and_valid_story_fields(self):
         """
         Tests invalid input for all story fields. The correct error
         message should appear and no additional nodes should exist.
@@ -144,6 +145,23 @@ class AddNodeFromUserTests(LiveServerTestCase):
                     "longitude": 90
                 }
         self.assertTrue(invalid_title_err, user.post_node(invalid_node_dict))
+        # Test valid image response
+        test_image_path = "media/storyimages/test_image.jpeg"
+        test_image_file = SimpleUploadedFile(name='test_image.jpeg',
+                                             content=open(test_image_path, 'rb').read(),
+                                             content_type='image/jpeg')
+        valid_response = "Successfully Added your Story! Please refresh page to see changes."
+        invalid_node_dict = {
+                    "node_title": "titletitle",
+                    "node_content": "content",
+                    "image_file": test_image_file,
+                    "image_url": None,
+                    "main_tag_id": TagToInsert.id,
+                    "mature_node": False,
+                    "latitude": 90,
+                    "longitude": 90
+                }
+        self.assertTrue(valid_response, user.post_node(invalid_node_dict))
         return
 
     def test_existing_stories_and_tags_present(self):

--- a/story/tellmeastory/tests/test_integrated_nodecreation.py
+++ b/story/tellmeastory/tests/test_integrated_nodecreation.py
@@ -89,6 +89,19 @@ class AddNodeFromUserTests(LiveServerTestCase):
         password = "password1"
         display_name = "display"
         user = User.objects.create(username=username, password=sha512(password.encode("utf-8")).hexdigest(), display_name=display_name)
+        # Test invalid main tag response (when there are no tags at all)
+        invalid_main_tag_err = "Main Tag not found. Please select a valid main tag."
+        invalid_node_dict = {
+                    "node_title": "title",
+                    "node_content": "content",
+                    "image_file": None,
+                    "image_url": "www.google.com",
+                    "main_tag_id": 1,
+                    "mature_node": False,
+                    "latitude": 90,
+                    "longitude": 90
+                }
+        self.assertTrue(invalid_main_tag_err, user.post_node(invalid_node_dict))
         # Create test tag
         TagToInsert = Tag(name_text="name123", language="en_US")
         TagToInsert.add_new_tag() # Create Main Tag to Add
@@ -118,7 +131,7 @@ class AddNodeFromUserTests(LiveServerTestCase):
                     "latitude": 90,
                     "longitude": 90
                 }
-        self.assertTrue(invalid_title_err, user.post_node(invalid_node_dict))
+        self.assertTrue(invalid_content_err, user.post_node(invalid_node_dict))
         # Test invalid image response
         invalid_image_err = "Invalid Image. You may add one image to each story."
         invalid_node_dict = {
@@ -131,7 +144,7 @@ class AddNodeFromUserTests(LiveServerTestCase):
                     "latitude": 90,
                     "longitude": 90
                 }
-        self.assertTrue(invalid_title_err, user.post_node(invalid_node_dict))
+        self.assertTrue(invalid_image_err, user.post_node(invalid_node_dict))
         # Test invalid main tag response
         invalid_main_tag_err = "Main Tag not found. Please select a valid main tag."
         invalid_node_dict = {
@@ -144,7 +157,7 @@ class AddNodeFromUserTests(LiveServerTestCase):
                     "latitude": 90,
                     "longitude": 90
                 }
-        self.assertTrue(invalid_title_err, user.post_node(invalid_node_dict))
+        self.assertTrue(invalid_main_tag_err, user.post_node(invalid_node_dict))
         # Test valid image response
         test_image_path = "media/storyimages/test_image.jpeg"
         test_image_file = SimpleUploadedFile(name='test_image.jpeg',

--- a/story/tellmeastory/views.py
+++ b/story/tellmeastory/views.py
@@ -376,11 +376,23 @@ def author_story(req: HttpRequest, username: str) -> HttpResponse:
                         "error_message": err_msg
                     })
                 # CREATE STORY NODE FROM PROVIDED INFORMATION
+                # Null image if empty
+                try:
+                    image_file = req.FILES.get('image_file', None)
+                except:
+                    # Image_file should be none if no files given.
+                    # Failsafe if get throws an exception instead
+                    # of setting image_file to None for no files.
+                    image_file = None
+                image_url = form["image_url"].value()
+                # Null url if blank
+                if image_url == "":
+                    image_url = None
                 err_msg = user.post_node({
                     "node_title": form["node_title"].value().strip(),
                     "node_content": form["node_content"].value().strip(),
-                    "image_file": form["image_file"].value(),
-                    "image_url": form["image_url"].value(),
+                    "image_file": image_file,
+                    "image_url": image_url,
                     "main_tag_id": form["main_tag_id"].value(),
                     "mature_node": form["mature_node"].value(),
                     "latitude": form["latitude"].value(),


### PR DESCRIPTION
Fixed adding an image to a story when posting and adding invalid tags when no tags exist. Tests are added to story/tellmeastory/tests/test_integrated_nodecreation tests that should now have included these edge cases.