### PR TITLE
Fixed map 404 when not logged in

### DIFF
--- a/story/tellmeastory/templates/tellmeastory/map.html
+++ b/story/tellmeastory/templates/tellmeastory/map.html
@@ -107,7 +107,7 @@
         let latitude = event.lngLat.lat;
         let username = "{{logged_in_username}}";
 
-        if (username) {
+        if (username !== "None") {
             location.href = `/story/author-story/${username}/${longitude}/${latitude}/`;
         }
     });


### PR DESCRIPTION
Fixes a 404 when clicking the map and not logged in.
See Issue #90 for full explanation and fix description.